### PR TITLE
fix: save in different scenarios with hotkey

### DIFF
--- a/src/scenarios/basic-antd/plugin.tsx
+++ b/src/scenarios/basic-antd/plugin.tsx
@@ -214,7 +214,7 @@ export default async function registerPlugins() {
         });
         hotkey.bind('command+s', (e) => {
           e.preventDefault();
-          saveSchema();
+          saveSchema('basic-antd')
         });
       },
     };

--- a/src/scenarios/basic-fusion-with-single-component/plugin.tsx
+++ b/src/scenarios/basic-fusion-with-single-component/plugin.tsx
@@ -214,7 +214,7 @@ export default async function registerPlugins() {
         });
         hotkey.bind('command+s', (e) => {
           e.preventDefault();
-          saveSchema();
+          saveSchema('basic-fusion-with-single-component')
         });
       },
     };

--- a/src/scenarios/basic-fusion/plugin.tsx
+++ b/src/scenarios/basic-fusion/plugin.tsx
@@ -214,7 +214,7 @@ export default async function registerPlugins() {
         });
         hotkey.bind('command+s', (e) => {
           e.preventDefault();
-          saveSchema();
+          saveSchema('basic-fusion')
         });
       },
     };

--- a/src/scenarios/node-extended-actions/plugin.tsx
+++ b/src/scenarios/node-extended-actions/plugin.tsx
@@ -250,7 +250,7 @@ export default async function registerPlugins() {
         });
         hotkey.bind('command+s', (e) => {
           e.preventDefault();
-          saveSchema();
+          saveSchema('node-extended-actions')
         });
       },
     };

--- a/src/universal/utils.ts
+++ b/src/universal/utils.ts
@@ -269,16 +269,13 @@ export const getPackagesFromLocalStorage = (scenarioName: string) => {
   return JSON.parse(window.localStorage.getItem(getLSName(scenarioName, 'packages')) || '{}');
 }
 
-export const getPageSchema = async () => {
-  const schema = JSON.parse(
-    window.localStorage.getItem('projectSchema') || '{}'
-  );
-
-  const pageSchema = schema?.componentsTree?.[0];
+export const getPageSchema = async (scenarioName: string = 'index') => {
+  const pageSchema = getProjectSchemaFromLocalStorage(scenarioName).componentsTree?.[0]
 
   if (pageSchema) {
     return pageSchema;
   }
+
   return await request('./schema.json');
 };
 


### PR DESCRIPTION
#### 目前demo 发现两个问题：

- 综合场景(index) 未保存成功。
   - 原因：增加了通过不同场景读取schema，但未对index场景修改读取逻辑 ，导致读取schema问题
  
- 其他场景下通过快捷键保存，未保存成功。
  - 原因：快捷键保存，未传入对应场景名称

基于上述问题修复