### PR TITLE
fix: build.json增加打包后产出文件地址，方便配置

### DIFF
--- a/build.json
+++ b/build.json
@@ -7,6 +7,7 @@
     "hot": false
   },
   "publicPath": "/",
+  "outputDir": "build",
   "externals": {
     "react": "var window.React",
     "react-dom": "var window.ReactDOM",


### PR DESCRIPTION
npm run build 后产物默认在“build”目录下，不知道哪里改配置