### PR TITLE
chore: 解决预览的模拟器渲染库和编辑态的引擎库版本不一致的问题

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -11,7 +11,7 @@
     <link href="https://alifd.alicdn.com/npm/@alifd/theme-lowcode-light@0.2.1/variables.css" rel="stylesheet" />
     <link href="https://alifd.alicdn.com/npm/@alifd/theme-lowcode-light@0.2.1/dist/next.var.min.css" rel="stylesheet" />
     <!-- 低代码引擎的页面框架样式 -->
-    <link rel="stylesheet" href="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@1.0.8/dist/css/engine-core.css" />
+    <link rel="stylesheet" href="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@1.0.9/dist/css/engine-core.css" />
     <!-- 低代码引擎官方扩展的样式 -->
     <link rel="stylesheet" href="https://alifd.alicdn.com/npm/@alilc/lowcode-engine-ext@1.0.3/dist/css/engine-ext.css" />
 
@@ -29,7 +29,7 @@
     <!-- Fusion Next 的主包，低代码编辑器的依赖 -->
     <script src="https://g.alicdn.com/code/lib/alifd__next/1.23.24/next.min.js"></script>
     <!-- 低代码引擎的主包 -->
-    <script crossorigin="anonymous" src="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@1.0.8/dist/js/engine-core.js"></script>
+    <script crossorigin="anonymous" src="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@1.0.9/dist/js/engine-core.js"></script>
     <!-- 低代码引擎官方扩展的主包 -->
     <script crossorigin="anonymous" src="https://alifd.alicdn.com/npm/@alilc/lowcode-engine-ext@1.0.3/dist/js/engine-ext.js"></script>
     <script>

--- a/src/scenarios/basic-antd/index.ts
+++ b/src/scenarios/basic-antd/index.ts
@@ -28,12 +28,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }

--- a/src/scenarios/basic-fusion-with-single-component/index.ts
+++ b/src/scenarios/basic-fusion-with-single-component/index.ts
@@ -28,12 +28,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }

--- a/src/scenarios/basic-fusion/index.ts
+++ b/src/scenarios/basic-fusion/index.ts
@@ -28,12 +28,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }

--- a/src/scenarios/custom-initialization/index.tsx
+++ b/src/scenarios/custom-initialization/index.tsx
@@ -44,12 +44,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }

--- a/src/scenarios/index/index.ts
+++ b/src/scenarios/index/index.ts
@@ -28,12 +28,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }

--- a/src/scenarios/node-extended-actions/index.ts
+++ b/src/scenarios/node-extended-actions/index.ts
@@ -29,12 +29,6 @@ preference.set('DataSourcePane', {
     enableCanvasLock: true,
     // 默认绑定变量
     supportVariableGlobally: true,
-    // simulatorUrl 在当 engine-core.js 同一个父路径下时是不需要配置的！！！
-    // 这里因为用的是 alifd cdn，在不同 npm 包，engine-core.js 和 react-simulator-renderer.js 是不同路径
-    simulatorUrl: [
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/css/react-simulator-renderer.css',
-      'https://alifd.alicdn.com/npm/@alilc/lowcode-react-simulator-renderer@latest/dist/js/react-simulator-renderer.js'
-    ],
     requestHandlersMap: {
       fetch: createFetchHandler()
     }


### PR DESCRIPTION
## 问题
1、项目中预览文件的renderer-core是直接引用的node_moudles里面的包；
2、编辑模式下，使用的是模板文件预置的远程地址，并指定了版本；
3、模拟器渲染使用的是@latest版本
以上都属于核心引擎库，模块有相互依赖，版本不一致会导致渲染出现问题。目前的Demo在对数据进行处理时就有不一致的现象。

## 现象
### 修改前
编辑态：数据处理中res直接取了data
![image](https://user-images.githubusercontent.com/22095959/172579552-3a70e248-8ee5-4236-884d-9e21196fdb97.png)
查看态：数据处理中res包含网络状态和Header等信息
![image](https://user-images.githubusercontent.com/22095959/172579857-e6ecb53b-e28f-413e-8c00-5848cffcb975.png)

### 修改后
编辑态：数据处理中也res包含网络状态和Header等信息
![image](https://user-images.githubusercontent.com/22095959/172580298-c2db66b8-32cf-4224-8535-77a8bfdf15dd.png)



