### PR TITLE
在README.md中新增yarn启动方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ demo 是一个组合内核、setter、插件、物料的示范工程，因为未
 ## 如何使用
 目前包含多个独立 demo 工程目录，每个 demo 目录都是一个独立的工程，代表一个特定的 demo 场景，可以选择其一单独使用。
 
+[推荐]使用yarn
+```bash
+git clone git@github.com:alibaba/lowcode-demo.git
+cd lowcode-demo
+cd demo-general
+yarn
+yarn run start
+```
+
+使用npm
 ```bash
 git clone git@github.com:alibaba/lowcode-demo.git
 cd lowcode-demo

--- a/demo-general/src/services/mockService.ts
+++ b/demo-general/src/services/mockService.ts
@@ -1,11 +1,11 @@
 import { material, project } from '@alilc/lowcode-engine';
 import { filterPackages } from '@alilc/lowcode-plugin-inject'
 import { Message, Dialog } from '@alifd/next';
-import { ProjectSchema, TransformStage } from '@alilc/lowcode-types';
+import { IPublicTypeProjectSchema, IPublicEnumTransformStage } from '@alilc/lowcode-types';
 import DefaultPageSchema from './defaultPageSchema.json';
 import DefaultI18nSchema from './defaultI18nSchema.json';
 
-const generateProjectSchema = (pageSchema: any, i18nSchema: any): ProjectSchema => {
+const generateProjectSchema = (pageSchema: any, i18nSchema: any): IPublicTypeProjectSchema => {
   return {
     componentsTree: [pageSchema],
     componentsMap: material.componentsMap as any,
@@ -68,7 +68,7 @@ const setProjectSchemaToLocalStorage = (scenarioName: string) => {
   }
   window.localStorage.setItem(
     getLSName(scenarioName),
-    JSON.stringify(project.exportSchema(TransformStage.Save))
+    JSON.stringify(project.exportSchema(IPublicEnumTransformStage.Save))
   );
 }
 
@@ -92,7 +92,7 @@ export const getPackagesFromLocalStorage = (scenarioName: string) => {
   return JSON.parse(window.localStorage.getItem(getLSName(scenarioName, 'packages')) || '{}');
 }
 
-export const getProjectSchema = async (scenarioName: string = 'unknown') : Promise<ProjectSchema> => {
+export const getProjectSchema = async (scenarioName: string = 'unknown') : Promise<IPublicTypeProjectSchema> => {
   const pageSchema = await getPageSchema(scenarioName);
   return generateProjectSchema(pageSchema, DefaultI18nSchema);
 };


### PR DESCRIPTION
我一开始启动项目按照文档中的npm run start启动项目会报错，然后用yarn试了一遍没有问题。推荐文档上将yarn设为推荐启动方式
```bash
git clone git@github.com:alibaba/lowcode-demo.git
cd lowcode-demo
cd demo-general
yarn
yarn run start
```